### PR TITLE
Remove upper version constraint on mercenary

### DIFF
--- a/octopress.gemspec
+++ b/octopress.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mercenary", "~> 0.3.2"
+  spec.add_runtime_dependency "mercenary", ">= 0.3.2"
   spec.add_runtime_dependency "jekyll", ">= 2.0"
   spec.add_runtime_dependency "titlecase"
   spec.add_runtime_dependency "octopress-deploy"


### PR DESCRIPTION
It doesn't seem like there's a specific reason to disallow higher minor versions of Mercenary, and this constraint prevents Octopress being used with the most recent version of Jekyll (which requires `~> 0.4.0`).